### PR TITLE
Improve template usage

### DIFF
--- a/Application.sln
+++ b/Application.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StartProject", "src\StartProject\StartProject.csproj", "{8F6449AB-4560-40B1-835E-308F1534734C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MyApplication", "src\MyApplication\MyApplication.csproj", "{DF4730D4-5DB2-46A5-9F2B-C7B22E61268B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{8F6449AB-4560-40B1-835E-308F1534734C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F6449AB-4560-40B1-835E-308F1534734C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F6449AB-4560-40B1-835E-308F1534734C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF4730D4-5DB2-46A5-9F2B-C7B22E61268B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF4730D4-5DB2-46A5-9F2B-C7B22E61268B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF4730D4-5DB2-46A5-9F2B-C7B22E61268B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF4730D4-5DB2-46A5-9F2B-C7B22E61268B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -1,3 +1,38 @@
 # MORYX Template
 
-Recommended repository template for quickly starting the development of MORYX modules, plugins or entire applications. This template has the necessary package feeds, a front-end and back-end solution, each with a launchable *StartProject*. Just clone the repository, open the solution and run the application to check. You can then add more packages or start developing your own MORYX packages.
+[![Gitter](https://badges.gitter.im/MORYX-Industry/Development.svg)](https://gitter.im/MORYX-Industry/Development?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
+Recommended repository template for quickly starting the development of MORYX modules, plugins or entire applications. This template has the necessary package feeds, a back-end (*Application.sln*) and front-end (*Application.UI.sln*) solution, each with a launchable *StartProject*. The back-end solution is also pre-configured with the *Maintenance* module and graphic interface [MaintenanceWeb](https://github.com/PHOENIXCONTACT/MORYX-MaintenanceWeb), which you can use to interact with modules and change their configuration. The empty project *MyApplication* is your projects root namespace. It may contain facade, interface and domain model definitions. Remove it, if you do not need cross project type definitions.
+
+## Getting Started
+
+You can either use this repository as a template directly on GitHub or clone it like any other GIT repository. Afterwards just open the solutions and run the application. Per default this will require access to port 80, alternative you can configure a different port in the **WcfConfig* within the *StartProject*. While the server is running you can open the *MaintenanceWeb* at http://localhost/maintenanceweb/. The *Dashboard* gives you an overview of the application, *Modules* is used to interact and configure modules, *Models* lets you create databases and schemas for installed data models, while *Log* grants live access to all logs.
+
+You can extend your solution by adding more packages to your *StartProject* or creating a MORYX package of your own. This repository includes [branches](#branches) with templates for common MORYX repositories. For details on different MORYX package types and documentation refer to the [MORYX-Platform](https://github.com/PHOENIXCONTACT/MORYX-Platform), [MORYX-CientFramework](https://github.com/PHOENIXCONTACT/MORYX-ClientFramework) and [MORYX-AbstractionLayer](https://github.com/PHOENIXCONTACT/MORYX-AbstractionLayer).
+
+The projects, that you create yourself, need to be loaded in MORYX. Add a reference to your project in the *StartProject*. This will make sure, that your project is build every time you start debugging. It also ensures, that all your projects dependencies are present in the *StartProjects* execution directory and that the binary is removed on clean-up.
+
+## Branches
+
+The *master* branch of this template is the bare minimum most developers will need to start, whether the build an application, a reusable module or a plugin to extend an existing module. There is a range of specialized branches for different use cases and tasks. Some branches include small class stubs, which you can either delete or adjust to your use case. You can start from a branch or merge it into *master*. With the merging technique you can also combine multiple templates by merging their branches into `master`. Below is a list of branches and their content:
+
+- **master:** Base template with front- and back-end solution, *StartProject** and pre-installed *Maintenance* and *MaintenanceWeb*.
+    - **[module](https://github.com/PHOENIXCONTACT/MORYX-Template/tree/module):** Empty module project with standard directory structure, *ModuleController*, *ModuleConfig* and *ModuleConsole*. 
+    - **[al/resources](https://github.com/PHOENIXCONTACT/MORYX-Template/tree/al/resources):** Pre-installed *ResourceManagement* packages in front- and back-end, empty resource project, prepared configuration and setup instructions.
+    - **[al/products](https://github.com/PHOENIXCONTACT/MORYX-Template/tree/al/products):** Pre-installed *ProductManagement* packages in front- and back-end, product definition stubs, prepared configuration and setup instructions.
+
+**Note:** When you use this as a template on GitHub all branches are rewritten as initial commits and they lose their common ancestry, therefore can no longer be merged. The solution is to use `git replace --graft <template_branch> HEAD` from `master` **before** merging any branch. This will rewrite the commits parent and restore the lost ancestry. Afterwards you can use standard `git merge <template_branch>`. After assembling your initial template, remove all other branches for a clean repository.
+
+## Inspirations
+
+For inspiration, best practices and reusable packages, take a look at the MORYX based projects below. Open an issue or pull request, if you would like to add your project to the list.
+
+- [HoMory](https://github.com/Toxantron/HoMory): MORYX based HomeAutomation example
+
+## Trouble Shooting
+
+If you run into problems with the template or MORYX development in general, feel free to join our Gitter channel, ask on StackOverflow using the [`moryx`](https://stackoverflow.com/questions/tagged/moryx) tag or open an issue. In case your back-end application closes directly after start, this is mostly caused by lack of rights, reserved ports or missing libraries. MORYX creates crash log before exiting which can be find in the subdirectory *CrashLogs* in the *StartProjects* execution directory.
+
+## Contribute
+
+If you have an idea to improve a template or can think of a new useful template, please make your changes based on one of the template branches and open a pull request. If you want to add a template, extend the branch list in one commit and the template definition in another. This way we can easily put your template into a separate branch. **Note:** All branches except *master* will be rebased and squashed regularly, to keep them clean. All merge requests that went into a template branch will combined in a single commit and its message appended with following merge request ids.  

--- a/src/MyApplication/MyApplication.csproj
+++ b/src/MyApplication/MyApplication.csproj
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DF4730D4-5DB2-46A5-9F2B-C7B22E61268B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MyApplication</RootNamespace>
+    <AssemblyName>MyApplication</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Moryx, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.3.0.0-dev.37\lib\netstandard2.0\Moryx.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/MyApplication/Properties/AssemblyInfo.cs
+++ b/src/MyApplication/Properties/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MyApplication")]
+[assembly: AssemblyCompany("Your Company")]
+[assembly: AssemblyCopyright("Copyright © Your Company 2020")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/MyApplication/app.config
+++ b/src/MyApplication/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.ComponentModel.Annotations" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/MyApplication/packages.config
+++ b/src/MyApplication/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Moryx" version="3.0.0-dev.37" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net461" />
+</packages>

--- a/src/StartProject.UI/App.config
+++ b/src/StartProject.UI/App.config
@@ -13,6 +13,10 @@
         <assemblyIdentity name="System.Windows.Interactivity" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="CommandLine" publicKeyToken="5a870481e358d379" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.8.0.0" newVersion="2.8.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/StartProject.UI/Config/Moryx.ClientFramework.AppConfig.json
+++ b/src/StartProject.UI/Config/Moryx.ClientFramework.AppConfig.json
@@ -1,0 +1,9 @@
+{
+  "Name": "MyApplication",
+  "Application": "HeartOfLead_XI2A",
+  "RunMode": "Local_RunMode",
+  "OpenConfigWithControl": true,
+  "LimitInstances": false,
+  "ViewPreset": "Default",
+  "ConfigState": "Generated"
+}

--- a/src/StartProject.UI/Config/Moryx.ClientFramework.ModulesConfiguration.json
+++ b/src/StartProject.UI/Config/Moryx.ClientFramework.ModulesConfiguration.json
@@ -1,0 +1,15 @@
+{
+  "Application": "NoName",
+  "Shell": {
+    "ShellName": "SimpleShell"
+  },
+  "Modules": [
+    {
+      "ModuleName": "Wcf Viewer",
+      "IsEnabled": true,
+      "SortIndex": 9999,
+      "Accesses": {}
+    }
+  ],
+  "ConfigState": "Generated"
+}

--- a/src/StartProject.UI/Config/Moryx.ClientFramework.RuntimeConfig.json
+++ b/src/StartProject.UI/Config/Moryx.ClientFramework.RuntimeConfig.json
@@ -1,0 +1,6 @@
+{
+  "Host": "localhost",
+  "Port": 80,
+  "ClientId": "MyClient",
+  "ConfigState": "Generated"
+}

--- a/src/StartProject.UI/Properties/AssemblyInfo.cs
+++ b/src/StartProject.UI/Properties/AssemblyInfo.cs
@@ -7,19 +7,9 @@ using System.Windows;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("StartProject.UI")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("PHOENIX CONTACT GmbH & Co. KG")]
-[assembly: AssemblyProduct("HumidificationUI")]
-[assembly: AssemblyCopyright("Copyright © PHOENIX CONTACT GmbH & Co. KG 2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
+[assembly: AssemblyTitle("Your Application UI")]
+[assembly: AssemblyCompany("Your Company")]
+[assembly: AssemblyCopyright("Copyright © Your Company 2020")]
 
 //In order to begin building localizable applications, set 
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file

--- a/src/StartProject.UI/StartProject.UI.csproj
+++ b/src/StartProject.UI/StartProject.UI.csproj
@@ -52,13 +52,13 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
+      <HintPath>..\..\packages\Castle.Core.4.4.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Windsor, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Windsor.5.0.1\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
-    <Reference Include="CommandLine, Version=2.7.82.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CommandLineParser.2.7.82\lib\net461\CommandLine.dll</HintPath>
+    <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\CommandLineParser.2.8.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="Controls4Industry, Version=3.0.0.20, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Controls4Industry.3.0.0-dev.20\lib\net461\Controls4Industry.dll</HintPath>
@@ -66,8 +66,8 @@
     <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\Microsoft.Expression.Interactions.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx, Version=3.0.0.26, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.3.0.0-dev.26\lib\netstandard2.0\Moryx.dll</HintPath>
+    <Reference Include="Moryx, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.3.0.0-dev.37\lib\netstandard2.0\Moryx.dll</HintPath>
     </Reference>
     <Reference Include="Moryx.ClientFramework, Version=3.0.0.20, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moryx.ClientFramework.3.0.0-dev.20\lib\net461\Moryx.ClientFramework.dll</HintPath>
@@ -81,17 +81,17 @@
     <Reference Include="Moryx.ClientFramework.SimpleShell, Version=3.0.0.20, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moryx.ClientFramework.SimpleShell.3.0.0-dev.20\lib\net461\Moryx.ClientFramework.SimpleShell.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx.Container, Version=3.0.0.26, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.Container.3.0.0-dev.26\lib\netstandard2.0\Moryx.Container.dll</HintPath>
+    <Reference Include="Moryx.Container, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Container.3.0.0-dev.37\lib\netstandard2.0\Moryx.Container.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx.Controls, Version=3.0.0.15, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.Controls.3.0.0-dev.15\lib\net461\Moryx.Controls.dll</HintPath>
+    <Reference Include="Moryx.Controls, Version=3.0.0.20, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Controls.3.0.0-dev.20\lib\net461\Moryx.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx.Tools.Wcf, Version=3.0.0.26, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.Tools.Wcf.3.0.0-dev.26\lib\net461\Moryx.Tools.Wcf.dll</HintPath>
+    <Reference Include="Moryx.Tools.Wcf, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Tools.Wcf.3.0.0-dev.37\lib\net461\Moryx.Tools.Wcf.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx.Tools.WcfClient.UI.Viewer, Version=3.0.0.15, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.Tools.WcfClient.UI.Viewer.3.0.0-dev.15\lib\net461\Moryx.Tools.WcfClient.UI.Viewer.dll</HintPath>
+    <Reference Include="Moryx.Tools.WcfClient.UI.Viewer, Version=3.0.0.20, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Tools.WcfClient.UI.Viewer.3.0.0-dev.20\lib\net461\Moryx.Tools.WcfClient.UI.Viewer.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -100,14 +100,17 @@
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ComponentModel.Annotations.4.7.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
     </Reference>
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Console.4.0.0-rc2-24027\lib\net46\System.Console.dll</HintPath>
+    <Reference Include="System.Console, Version=4.0.1.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.3.1\lib\net46\System.Console.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Data" />
-    <Reference Include="System.Reflection.TypeExtensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.TypeExtensions.4.1.0-rc2-24027\lib\net46\System.Reflection.TypeExtensions.dll</HintPath>
+    <Reference Include="System.Reflection.TypeExtensions, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.TypeExtensions.4.7.0\lib\net461\System.Reflection.TypeExtensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Remoting" />
     <Reference Include="System.Web" />

--- a/src/StartProject.UI/StartProject.UI.csproj
+++ b/src/StartProject.UI/StartProject.UI.csproj
@@ -149,6 +149,15 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="Config\Moryx.ClientFramework.AppConfig.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Config\Moryx.ClientFramework.ModulesConfiguration.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Config\Moryx.ClientFramework.RuntimeConfig.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/src/StartProject.UI/packages.config
+++ b/src/StartProject.UI/packages.config
@@ -2,34 +2,34 @@
 <packages>
   <package id="Caliburn.Micro" version="3.2.0" targetFramework="net461" />
   <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net461" />
-  <package id="Castle.Core" version="4.4.0" targetFramework="net461" />
+  <package id="Castle.Core" version="4.4.1" targetFramework="net461" />
   <package id="Castle.Windsor" version="5.0.1" targetFramework="net461" />
-  <package id="CommandLineParser" version="2.7.82" targetFramework="net461" />
+  <package id="CommandLineParser" version="2.8.0" targetFramework="net461" />
   <package id="Controls4Industry" version="3.0.0-dev.20" targetFramework="net461" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net461" />
-  <package id="Moryx" version="3.0.0-dev.26" targetFramework="net461" />
+  <package id="Moryx" version="3.0.0-dev.37" targetFramework="net461" />
   <package id="Moryx.ClientFramework" version="3.0.0-dev.20" targetFramework="net461" />
   <package id="Moryx.ClientFramework.Configurator" version="3.0.0-dev.20" targetFramework="net461" />
   <package id="Moryx.ClientFramework.Kernel" version="3.0.0-dev.20" targetFramework="net461" />
   <package id="Moryx.ClientFramework.SimpleShell" version="3.0.0-dev.20" targetFramework="net461" />
-  <package id="Moryx.Container" version="3.0.0-dev.26" targetFramework="net461" />
-  <package id="Moryx.Controls" version="3.0.0-dev.15" targetFramework="net461" />
-  <package id="Moryx.Tools.Wcf" version="3.0.0-dev.26" targetFramework="net461" />
-  <package id="Moryx.Tools.WcfClient.UI.Viewer" version="3.0.0-dev.15" targetFramework="net461" />
+  <package id="Moryx.Container" version="3.0.0-dev.37" targetFramework="net461" />
+  <package id="Moryx.Controls" version="3.0.0-dev.20" targetFramework="net461" />
+  <package id="Moryx.Tools.Wcf" version="3.0.0-dev.37" targetFramework="net461" />
+  <package id="Moryx.Tools.WcfClient.UI.Viewer" version="3.0.0-dev.20" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
-  <package id="System.Collections" version="4.0.11-rc2-24027" targetFramework="net461" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.ComponentModel.Annotations" version="4.7.0" targetFramework="net461" />
-  <package id="System.Console" version="4.0.0-rc2-24027" targetFramework="net461" />
-  <package id="System.Diagnostics.Debug" version="4.0.11-rc2-24027" targetFramework="net461" />
-  <package id="System.Globalization" version="4.0.11-rc2-24027" targetFramework="net461" />
-  <package id="System.IO" version="4.1.0-rc2-24027" targetFramework="net461" />
-  <package id="System.Linq" version="4.1.0-rc2-24027" targetFramework="net461" />
-  <package id="System.Linq.Expressions" version="4.0.11-rc2-24027" targetFramework="net461" />
-  <package id="System.Reflection" version="4.1.0-rc2-24027" targetFramework="net461" />
-  <package id="System.Reflection.Extensions" version="4.0.1-rc2-24027" targetFramework="net461" />
-  <package id="System.Reflection.TypeExtensions" version="4.1.0-rc2-24027" targetFramework="net461" />
-  <package id="System.Resources.ResourceManager" version="4.0.1-rc2-24027" targetFramework="net461" />
-  <package id="System.Runtime" version="4.1.0-rc2-24027" targetFramework="net461" />
-  <package id="System.Runtime.Extensions" version="4.1.0-rc2-24027" targetFramework="net461" />
+  <package id="System.Console" version="4.3.1" targetFramework="net461" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net461" />
+  <package id="System.IO" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net461" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net461" />
+  <package id="System.Reflection.TypeExtensions" version="4.7.0" targetFramework="net461" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime" version="4.3.1" targetFramework="net461" />
+  <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net461" />
   <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net461" />
 </packages>

--- a/src/StartProject/Config/Moryx.Tools.Wcf.WcfConfig.json
+++ b/src/StartProject/Config/Moryx.Tools.Wcf.WcfConfig.json
@@ -1,0 +1,10 @@
+{
+  "Host": "localhost",
+  "HttpPort": 80,
+  "NetTcpPort": 816,
+  "ConfigState": "Valid",
+  "OpenTimeout": 30,
+  "CloseTimeout": 30,
+  "SendTimeout": 30,
+  "ReceiveTimeout": -1
+}

--- a/src/StartProject/Properties/AssemblyInfo.cs
+++ b/src/StartProject/Properties/AssemblyInfo.cs
@@ -2,25 +2,14 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+// MORYX reads these attributes to determine your applications name and version
+
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("StartProject")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("PHOENIX CONTACT GmbH & Co. KG")]
-[assembly: AssemblyProduct("StartProject")]
-[assembly: AssemblyCopyright("Copyright © PHOENIX CONTACT GmbH & Co. KG 2019")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("8f6449ab-4560-40b1-835e-308f1534734c")]
+[assembly: AssemblyCompany("Your Company")]
+[assembly: AssemblyCopyright("Copyright © Your Company 2020")]
 
 // Version information for an assembly consists of the following four values:
 //
@@ -34,5 +23,3 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-
-[assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4net.config")]

--- a/src/StartProject/StartProject.csproj
+++ b/src/StartProject/StartProject.csproj
@@ -112,6 +112,9 @@
     <None Include="Config\log4net.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="Config\Moryx.Tools.Wcf.WcfConfig.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup />

--- a/src/StartProject/StartProject.csproj
+++ b/src/StartProject/StartProject.csproj
@@ -57,23 +57,29 @@
     <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx, Version=3.0.0.26, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.3.0.0-dev.26\lib\netstandard2.0\Moryx.dll</HintPath>
+    <Reference Include="Moryx, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.3.0.0-dev.37\lib\netstandard2.0\Moryx.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx.Container, Version=3.0.0.26, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.Container.3.0.0-dev.26\lib\netstandard2.0\Moryx.Container.dll</HintPath>
+    <Reference Include="Moryx.Container, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Container.3.0.0-dev.37\lib\netstandard2.0\Moryx.Container.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx.Runtime, Version=3.0.0.26, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.Runtime.3.0.0-dev.26\lib\netstandard2.0\Moryx.Runtime.dll</HintPath>
+    <Reference Include="Moryx.Runtime, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Runtime.3.0.0-dev.37\lib\netstandard2.0\Moryx.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx.Runtime.Kernel, Version=3.0.0.26, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.Runtime.Kernel.3.0.0-dev.26\lib\net461\Moryx.Runtime.Kernel.dll</HintPath>
+    <Reference Include="Moryx.Runtime.Kernel, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Runtime.Kernel.3.0.0-dev.37\lib\net461\Moryx.Runtime.Kernel.dll</HintPath>
     </Reference>
-    <Reference Include="Moryx.Tools.Wcf, Version=3.0.0.26, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moryx.Tools.Wcf.3.0.0-dev.26\lib\net461\Moryx.Tools.Wcf.dll</HintPath>
+    <Reference Include="Moryx.Runtime.Maintenance, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Runtime.Maintenance.3.0.0-dev.37\lib\net461\Moryx.Runtime.Maintenance.dll</HintPath>
+    </Reference>
+    <Reference Include="Moryx.Runtime.Maintenance.Web, Version=3.0.0.19, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Runtime.Maintenance.Web.3.0.0-dev.19\lib\net461\Moryx.Runtime.Maintenance.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="Moryx.Tools.Wcf, Version=3.0.0.37, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moryx.Tools.Wcf.3.0.0-dev.37\lib\net461\Moryx.Tools.Wcf.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/StartProject/StartProject.csproj
+++ b/src/StartProject/StartProject.csproj
@@ -117,6 +117,11 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <ProjectReference Include="..\MyApplication\MyApplication.csproj">
+      <Project>{df4730d4-5db2-46a5-9f2b-c7b22e61268b}</Project>
+      <Name>MyApplication</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/StartProject/packages.config
+++ b/src/StartProject/packages.config
@@ -9,11 +9,13 @@
   <package id="Common.Logging.Log4Net208" version="3.4.1" targetFramework="net461" />
   <package id="log4net" version="2.0.8" targetFramework="net461" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net461" />
-  <package id="Moryx" version="3.0.0-dev.26" targetFramework="net461" />
-  <package id="Moryx.Container" version="3.0.0-dev.26" targetFramework="net461" />
-  <package id="Moryx.Runtime" version="3.0.0-dev.26" targetFramework="net461" />
-  <package id="Moryx.Runtime.Kernel" version="3.0.0-dev.26" targetFramework="net461" />
-  <package id="Moryx.Tools.Wcf" version="3.0.0-dev.26" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Moryx" version="3.0.0-dev.37" targetFramework="net461" />
+  <package id="Moryx.Container" version="3.0.0-dev.37" targetFramework="net461" />
+  <package id="Moryx.Runtime" version="3.0.0-dev.37" targetFramework="net461" />
+  <package id="Moryx.Runtime.Kernel" version="3.0.0-dev.37" targetFramework="net461" />
+  <package id="Moryx.Runtime.Maintenance" version="3.0.0-dev.37" targetFramework="net461" />
+  <package id="Moryx.Runtime.Maintenance.Web" version="3.0.0-dev.19" targetFramework="net461" />
+  <package id="Moryx.Tools.Wcf" version="3.0.0-dev.37" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
The standard template was extended with more commonly used packages like the maintenance and detailed instructions. I also added new template branches for use cases like module creation or AbstractionLayer based applications.

This should be much easier to use and work out of the box when following the instructions.