### PR TITLE
Fixed name of Directory.Build.targets and space/tab mix in csproj

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -9,7 +9,7 @@
     <Product>Your Product</Product>
 
     <CurrentYear>$([System.DateTime]::Now.ToString("yyyy"))</CurrentYear>
-    <Copyright>Copyright © $(Company) $(CurrentYear)</Copyright>    
+    <Copyright>Copyright © $(Company) $(CurrentYear)</Copyright>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,7 +3,7 @@
 
   <!-- Central package version management -->
   <PropertyGroup>
-    <MoryxPlatformVersion>3.4.2</MoryxPlatformVersion>
+    <MoryxCoreVersion>3.4.2</MoryxCoreVersion>
     <MoryxClientFrameworkVersion>3.2.1</MoryxClientFrameworkVersion>
     <MoryxMaintenanceWebVersion>3.1.1</MoryxMaintenanceWebVersion>
     <MoryxAbstractionLayerVersion>5.12.1</MoryxAbstractionLayerVersion>
@@ -19,18 +19,18 @@
     <PackageReference Update="NUnit" Version="3.12.0" />
 
     <!--Platform dependencies-->
-    <PackageReference Update="Moryx" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.TestTools.UnitTest" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.Model.InMemory" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.Model.PostgreSQL" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.Container" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.Runtime" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.Runtime.Kestrel" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.Runtime.Kernel" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.Runtime.Maintenance" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.Runtime.SmokeTest" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.Asp.Extensions" Version="$(MoryxPlatformVersion)"/>
-    <PackageReference Update="Moryx.TestTools.UnitTest" Version="$(MoryxPlatformVersion)" />
+    <PackageReference Update="Moryx" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.TestTools.UnitTest" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.Model.InMemory" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.Model.PostgreSQL" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.Container" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.Runtime" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.Runtime.Kestrel" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.Runtime.Kernel" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.Runtime.Maintenance" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.Runtime.SmokeTest" Version="$(MoryxCoreVersion)" />
+    <PackageReference Update="Moryx.Asp.Extensions" Version="$(MoryxCoreVersion)"/>
+    <PackageReference Update="Moryx.TestTools.UnitTest" Version="$(MoryxCoreVersion)" />
 
     <!--Maintenance dependencies-->
     <PackageReference Update="Moryx.Runtime.Maintenance.Web" Version="$(MoryxMaintenanceWebVersion)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,9 +3,9 @@
 
   <!-- Central package version management -->
   <PropertyGroup>
-    <MoryxPlatformVersion>3.4.1</MoryxPlatformVersion>
+    <MoryxPlatformVersion>3.4.2</MoryxPlatformVersion>
     <MoryxClientFrameworkVersion>3.2.1</MoryxClientFrameworkVersion>
-    <MoryxMaintenanceWebVersion>3.1.1</MoryxMaintenanceWebVersion>    
+    <MoryxMaintenanceWebVersion>3.1.1</MoryxMaintenanceWebVersion>
     <MoryxAbstractionLayerVersion>5.12.1</MoryxAbstractionLayerVersion>
     <MoryxFactoryVersion>4.2.0</MoryxFactoryVersion>
   </PropertyGroup>
@@ -20,7 +20,7 @@
 
     <!--Platform dependencies-->
     <PackageReference Update="Moryx" Version="$(MoryxPlatformVersion)" />
-    <PackageReference Update="Moryx.TestTools.UnitTest" Version="$(MoryxPlatformVersion)" />    
+    <PackageReference Update="Moryx.TestTools.UnitTest" Version="$(MoryxPlatformVersion)" />
     <PackageReference Update="Moryx.Model.InMemory" Version="$(MoryxPlatformVersion)" />
     <PackageReference Update="Moryx.Model.PostgreSQL" Version="$(MoryxPlatformVersion)" />
     <PackageReference Update="Moryx.Container" Version="$(MoryxPlatformVersion)" />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MORYX Template
 
-<p align="center">    
+<p align="center">
     <a href="https://stackoverflow.com/questions/tagged/moryx">
         <img src="https://img.shields.io/badge/stackoverflow-ask-orange.svg" alt="Stackoverflow">
     </a>
@@ -17,7 +17,7 @@ This template also uses the SDK project style for simplified project definition 
 
 You can either use this repository as a template directly on GitHub or clone it like any other GIT repository. Afterwards just open the solutions and run the application. Per default this will require access to port 5002, alternative you can configure a different port in the **PortConfig* within the *StartProject*. While the server is running you can open the *MaintenanceWeb* at http://localhost:5002/maintenanceweb/ or the appropriate host (127.0.0.1 / host name / ...). The *Dashboard* gives you an overview of the application, *Modules* is used to interact and configure modules, *Models* lets you create databases and schemas for installed data models, while *Log* grants live access to all logs.
 
-You can extend your solution by adding more packages to your *StartProject* or creating a MORYX package of your own. This repository includes [branches](#branches) with templates for common MORYX repositories. For details on different MORYX package types and documentation refer to the [MORYX-Platform](https://github.com/PHOENIXCONTACT/MORYX-Platform), [MORYX-CientFramework](https://github.com/PHOENIXCONTACT/MORYX-ClientFramework) and [MORYX-AbstractionLayer](https://github.com/PHOENIXCONTACT/MORYX-AbstractionLayer).
+You can extend your solution by adding more packages to your *StartProject* or creating a MORYX package of your own. This repository includes [branches](#branches) with templates for common MORYX repositories. For details on different MORYX package types and documentation refer to the [MORYX-Core](https://github.com/PHOENIXCONTACT/MORYX-Core), [MORYX-CientFramework](https://github.com/PHOENIXCONTACT/MORYX-ClientFramework) and [MORYX-AbstractionLayer](https://github.com/PHOENIXCONTACT/MORYX-AbstractionLayer).
 
 The projects, that you create yourself, need to be loaded in MORYX. Add a reference to your project in the *StartProject*. This will make sure, that your project is build every time you start debugging. It also ensures, that all your projects dependencies are present in the *StartProjects* execution directory and that the binary is removed on clean-up.
 
@@ -26,7 +26,7 @@ The projects, that you create yourself, need to be loaded in MORYX. Add a refere
 The *master* branch of this template is the bare minimum most developers will need to start, whether the build an application, a reusable module or a plugin to extend an existing module. There is a range of specialized branches for different use cases and tasks. Some branches include small class stubs, which you can either delete or adjust to your use case. You can start from a branch or merge it into *master*. With the merging technique you can also combine multiple templates by merging their branches into `master`. Below is a list of branches and their content:
 
 - **master:** Base template with front- and back-end solution, *StartProject** and pre-installed *Maintenance* and *MaintenanceWeb*.
-    - **[module](https://github.com/PHOENIXCONTACT/MORYX-Template/tree/module):** Empty module project with standard directory structure, *ModuleController*, *ModuleConfig* and *ModuleConsole*. 
+    - **[module](https://github.com/PHOENIXCONTACT/MORYX-Template/tree/module):** Empty module project with standard directory structure, *ModuleController*, *ModuleConfig* and *ModuleConsole*.
     - **[al/resources](https://github.com/PHOENIXCONTACT/MORYX-Template/tree/al/resources):** Pre-installed *ResourceManagement* packages in front- and back-end, empty resource project, prepared configuration and setup instructions.
     - **[al/products](https://github.com/PHOENIXCONTACT/MORYX-Template/tree/al/products):** Pre-installed *ProductManagement* packages in front- and back-end, product definition stubs, prepared configuration and setup instructions.
 

--- a/src/StartProject.UI/StartProject.UI.csproj
+++ b/src/StartProject.UI/StartProject.UI.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net45</TargetFramework>
     <UseWPF>true</UseWPF>
     <OutputType>WinExe</OutputType>
-    <StartupObject>StartProject.UI.Program</StartupObject>    
+    <StartupObject>StartProject.UI.Program</StartupObject>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/src/StartProject/StartProject.csproj
+++ b/src/StartProject/StartProject.csproj
@@ -3,24 +3,24 @@
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
-	
+
   <ItemGroup>
-	<PackageReference Include="Moryx.Runtime.Maintenance" />
-	<PackageReference Include="Moryx.Runtime.Kernel" />
+    <PackageReference Include="Moryx.Runtime.Maintenance" />
+    <PackageReference Include="Moryx.Runtime.Kernel" />
     <PackageReference Include="Moryx.Runtime.Kestrel" />
     <PackageReference Include="Moryx.Asp.Extensions" />
 
-	<PackageReference Include="Moryx.Runtime.Maintenance.Web" />
+    <PackageReference Include="Moryx.Runtime.Maintenance.Web" />
   </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\MyApplication\MyApplication.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MyApplication\MyApplication.csproj" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <None Update="Config\Moryx.Communication.PortConfig.json">
-            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="Config\Moryx.Communication.PortConfig.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- The `Directory.Build.targets` file is strong named under unix systems and ignored if named `Directory.build.targets`
- Fixed mix of spaces / tabs in csproj 
- Updated to the latest MORYX-Core
- Renamed MORYX-Platform to MORYX-Core

@Toxantron maybe you should think about an editorconfig used in MORYX projects to harmonize the configuration

Example (snippet of the default visual studio editor config): 

````txt
# All files
[*]
indent_style = space
charset = utf-8
trim_trailing_whitespace = true
insert_final_newline = true

# XML project files
[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
indent_size = 2

# XML config files
[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
indent_size = 2

# Code files
[*.{cs,csx,vb,vbx}]
indent_size = 4
charset = utf-8-bom
````