### PR TITLE
Update Default Port to match description

### DIFF
--- a/src/MyApplication.App/Properties/launchSettings.json
+++ b/src/MyApplication.App/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:60572;http://localhost:60573"
+      "applicationUrl": "https://localhost:5000"
     }
   }
 }


### PR DESCRIPTION
In the [readme.md](https://github.com/PHOENIXCONTACT/MORYX-Template/tree/machine#run-the-application) it is stated that the default port ist 5000 when in fact it was 60572.
