### PR TITLE
Fix Configurations

### DIFF
--- a/src/MyApplication.App/Config/Moryx.Products.Management.ModuleConfig.json
+++ b/src/MyApplication.App/Config/Moryx.Products.Management.ModuleConfig.json
@@ -16,7 +16,7 @@
       "PluginName": "GenericRecipeStrategy",
       "JsonColumn": "Text8",
       "PropertyConfigs": [],
-      "TargetType": "Moryx.AbstractionLayer.Recipes.ProductRecipe"
+      "TargetType": "Moryx.AbstractionLayer.Recipes.ProductionRecipe"
     }
   ],
   "ConfigState": "Generated"

--- a/src/MyApplication.App/MyApplication.App.csproj
+++ b/src/MyApplication.App/MyApplication.App.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Moryx.Notifications.Web" />
     <PackageReference Include="Moryx.Orders.Endpoints" />
     <PackageReference Include="Moryx.Orders.Web" />
+    <PackageReference Include="Moryx.Resources.AssemblyInstruction"/>
   
     <!-- MORYX Worplans -->
     <PackageReference Include="Moryx.Workplans.Editing" />


### PR DESCRIPTION
Add package reference to `Moryx.Resources.AssemblyInstructions` to be able to use the `VisualInstructor`.
Change `ProductRecipe` to `ProductionRecipe` in the Config, since that's the recipe needed for production