### PR TITLE
Add OS dependent wibu file paths

### DIFF
--- a/src/MyApplication.App/MyApplication.App.csproj
+++ b/src/MyApplication.App/MyApplication.App.csproj
@@ -35,13 +35,22 @@
     </None>
   </ItemGroup>
 
-
-  <ItemGroup>
-    <Compile Remove="$(NugetPackageRoot)\**\*.WibuCmRaU" />
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+    <Compile Remove="$(UserProfile)\**\*.WibuCmRaU" />
   </ItemGroup>
  
-	<ItemGroup>
-		<None Include="$(NugetPackageRoot)\**\*.WibuCmRaU">
+	<ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+		<None Include="$(UserProfile)\**\*.WibuCmRaU">
+			<Link>%(Filename)%(Extension)</Link>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(OS)' == 'Unix'">
+		<Compile Remove="/root/.nuget/packages/**/*.WibuCmRaU" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(OS)' == 'Unix'">
+		<None Include="/root/.nuget/packages/**/*.WibuCmRaU">
 			<Link>%(Filename)%(Extension)</Link>
 		</None>
 	</ItemGroup>


### PR DESCRIPTION
Nuget packages (and the wibu demo licenses we provide with them) are located under different paths depending on the file system. This fact is now covered by the item groups in the .csproj file