### PR TITLE
Recombine the default template used by the CLI with the ADP branch

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -372,7 +372,7 @@ dotnet_diagnostic.IDE0062.severity = warning
 
 # IDE0073: File header
 dotnet_diagnostic.IDE0073.severity = warning
-file_header_template = Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+file_header_template = Copyright (c) 2025, Phoenix Contact GmbH & Co. KG\nLicensed under the Apache License, Version 2.0
 
 # IDE0161: Convert to file-scoped namespace
 dotnet_diagnostic.IDE0161.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,553 @@
+; EditorConfig to support per-solution formatting.
+; Use the EditorConfig VS add-in to make this work.
+; http://editorconfig.org/
+;
+; Here are some resources for what's supported for .NET/C#
+; https://kent-boogaart.com/blog/editorconfig-reference-for-c-developers
+; https://learn.microsoft.com/visualstudio/ide/editorconfig-code-style-settings-reference
+;
+; Be **careful** editing this because some of the rules don't support adding a severity level
+; For instance if you change to `dotnet_sort_system_directives_first = true:warning` (adding `:warning`)
+; then the rule will be silently ignored.
+
+; This is the default for the codeline.
+root = true
+
+[*]
+indent_style = space
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+indent_size = 4
+dotnet_sort_system_directives_first = true
+
+# Don't use this. qualifier
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+# use int x = .. over Int32
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+
+# use int.MaxValue over Int32.MaxValue
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# Require var all the time.
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Disallow throw expressions.
+csharp_style_throw_expression = false:suggestion
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+
+# Namespace settings
+csharp_style_namespace_declarations = file_scoped:silent
+
+# Brace settings
+csharp_prefer_braces = true:silent# Prefer curly braces even for one line of code
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+csharp_indent_labels = one_less_than_current
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_space_around_binary_operators = before_and_after
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_static_anonymous_function = true:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:suggestion
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+
+[*.{xml,config,*proj,nuspec,props,resx,targets,yml,tasks}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.{ps1,psm1}]
+indent_size = 4
+
+[*.sh]
+indent_size = 4
+end_of_line = lf
+
+[*.{razor,cshtml}]
+charset = utf-8-bom
+
+[*.{cs,vb}]
+
+# SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+dotnet_diagnostic.SYSLIB1054.severity = warning
+
+# CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1018.severity = warning
+
+# CA1047: Do not declare protected member in sealed type
+dotnet_diagnostic.CA1047.severity = warning
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = warning
+
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = warning
+
+# CA1510: Use ArgumentNullException throw helper
+dotnet_diagnostic.CA1510.severity = warning
+
+# CA1511: Use ArgumentException throw helper
+dotnet_diagnostic.CA1511.severity = warning
+
+# CA1512: Use ArgumentOutOfRangeException throw helper
+dotnet_diagnostic.CA1512.severity = warning
+
+# CA1513: Use ObjectDisposedException throw helper
+dotnet_diagnostic.CA1513.severity = warning
+
+# CA1725: Parameter names should match base declaration
+dotnet_diagnostic.CA1725.severity = suggestion
+
+# CA1802: Use literals where appropriate
+dotnet_diagnostic.CA1802.severity = warning
+
+# CA1805: Do not initialize unnecessarily
+dotnet_diagnostic.CA1805.severity = warning
+
+# CA1810: Do not initialize unnecessarily
+dotnet_diagnostic.CA1810.severity = warning
+
+# CA1821: Remove empty Finalizers
+dotnet_diagnostic.CA1821.severity = warning
+
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = warning
+dotnet_code_quality.CA1822.api_surface = private, internal
+
+# CA1823: Avoid unused private fields
+dotnet_diagnostic.CA1823.severity = warning
+
+# CA1825: Avoid zero-length array allocations
+dotnet_diagnostic.CA1825.severity = warning
+
+# CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
+dotnet_diagnostic.CA1826.severity = suggestion
+
+# CA1827: Do not use Count() or LongCount() when Any() can be used
+dotnet_diagnostic.CA1827.severity = warning
+
+# CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+dotnet_diagnostic.CA1828.severity = warning
+
+# CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1829.severity = warning
+
+# CA1830: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+dotnet_diagnostic.CA1830.severity = warning
+
+# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1831.severity = warning
+
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1832.severity = warning
+
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1833.severity = warning
+
+# CA1834: Consider using 'StringBuilder.Append(char)' when applicable
+dotnet_diagnostic.CA1834.severity = warning
+
+# CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+dotnet_diagnostic.CA1835.severity = warning
+
+# CA1836: Prefer IsEmpty over Count
+dotnet_diagnostic.CA1836.severity = warning
+
+# CA1837: Use 'Environment.ProcessId'
+dotnet_diagnostic.CA1837.severity = warning
+
+# CA1838: Avoid 'StringBuilder' parameters for P/Invokes
+dotnet_diagnostic.CA1838.severity = warning
+
+# CA1839: Use 'Environment.ProcessPath'
+dotnet_diagnostic.CA1839.severity = warning
+
+# CA1840: Use 'Environment.CurrentManagedThreadId'
+dotnet_diagnostic.CA1840.severity = warning
+
+# CA1841: Prefer Dictionary.Contains methods
+dotnet_diagnostic.CA1841.severity = warning
+
+# CA1842: Do not use 'WhenAll' with a single task
+dotnet_diagnostic.CA1842.severity = warning
+
+# CA1843: Do not use 'WaitAll' with a single task
+dotnet_diagnostic.CA1843.severity = warning
+
+# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
+dotnet_diagnostic.CA1844.severity = warning
+
+# CA1845: Use span-based 'string.Concat'
+dotnet_diagnostic.CA1845.severity = warning
+
+# CA1846: Prefer AsSpan over Substring
+dotnet_diagnostic.CA1846.severity = warning
+
+# CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
+dotnet_diagnostic.CA1847.severity = warning
+
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = warning
+
+# CA1854: Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+dotnet_diagnostic.CA1854.severity = warning
+
+# CA1855: Prefer 'Clear' over 'Fill'
+dotnet_diagnostic.CA1855.severity = warning
+
+# CA1856: Incorrect usage of ConstantExpected attribute
+dotnet_diagnostic.CA1856.severity = error
+
+# CA1857: A constant is expected for the parameter
+dotnet_diagnostic.CA1857.severity = warning
+
+# CA1858: Use 'StartsWith' instead of 'IndexOf'
+dotnet_diagnostic.CA1858.severity = warning
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+#From CA2007 docs: When writing code in an ASP.NET Core application, by default there is no SynchronizationContext or TaskScheduler, for which reason a ConfigureAwait wouldn't actually change any behavior.
+dotnet_diagnostic.CA2007.severity = none
+
+# CA2008: Do not create tasks without passing a TaskScheduler
+dotnet_diagnostic.CA2008.severity = warning
+
+# CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+dotnet_diagnostic.CA2009.severity = warning
+
+# CA2011: Avoid infinite recursion
+dotnet_diagnostic.CA2011.severity = warning
+
+# CA2012: Use ValueTask correctly
+dotnet_diagnostic.CA2012.severity = warning
+
+# CA2013: Do not use ReferenceEquals with value types
+dotnet_diagnostic.CA2013.severity = warning
+
+# CA2014: Do not use stackalloc in loops.
+dotnet_diagnostic.CA2014.severity = warning
+
+# CA2016: Forward the 'CancellationToken' parameter to methods that take one
+dotnet_diagnostic.CA2016.severity = warning
+
+# CA2022: Avoid inexact read with `Stream.Read`
+dotnet_diagnostic.CA2022.severity = warning
+
+# CA2200: Rethrow to preserve stack details
+dotnet_diagnostic.CA2200.severity = warning
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = warning
+
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.CA2208.severity = warning
+
+# CA2245: Do not assign a property to itself
+dotnet_diagnostic.CA2245.severity = warning
+
+# CA2246: Assigning symbol and its member in the same statement
+dotnet_diagnostic.CA2246.severity = warning
+
+# CA2249: Use string.Contains instead of string.IndexOf to improve readability.
+dotnet_diagnostic.CA2249.severity = warning
+
+# IDE0005: Remove unnecessary usings
+dotnet_diagnostic.IDE0005.severity = warning
+
+# IDE0011: Curly braces to surround blocks of code
+dotnet_diagnostic.IDE0011.severity = warning
+
+# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
+dotnet_diagnostic.IDE0020.severity = warning
+
+# IDE0029: Use coalesce expression (non-nullable types)
+dotnet_diagnostic.IDE0029.severity = warning
+
+# IDE0030: Use coalesce expression (nullable types)
+dotnet_diagnostic.IDE0030.severity = warning
+
+# IDE0031: Use null propagation
+dotnet_diagnostic.IDE0031.severity = warning
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
+dotnet_diagnostic.IDE0038.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# IDE0051: Remove unused private members
+dotnet_diagnostic.IDE0051.severity = warning
+
+# IDE0055: All formatting rules
+dotnet_diagnostic.IDE0055.severity = suggestion
+
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
+
+# IDE0060: Remove unused parameter
+dotnet_code_quality_unused_parameters = non_public:suggestion
+dotnet_diagnostic.IDE0060.severity = warning
+
+# IDE0062: Make local function static
+dotnet_diagnostic.IDE0062.severity = warning
+
+# IDE0073: File header
+dotnet_diagnostic.IDE0073.severity = warning
+file_header_template = Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+# IDE0161: Convert to file-scoped namespace
+dotnet_diagnostic.IDE0161.severity = warning
+
+# IDE0200: Lambda expression can be removed
+dotnet_diagnostic.IDE0200.severity = warning
+
+# IDE2000: Disallow multiple blank lines
+dotnet_style_allow_multiple_blank_lines_experimental = false:silent
+dotnet_diagnostic.IDE2000.severity = warning
+
+[{eng/tools/**.cs,**/{test,testassets,samples,Samples,perf,benchmarkapps,scripts,stress}/**.cs,src/Hosting/Server.IntegrationTesting/**.cs,src/Servers/IIS/IntegrationTesting.IIS/**.cs,src/Shared/Http2cat/**.cs,src/Testing/**.cs}]
+# CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.CA1018.severity = suggestion
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.CA1507.severity = suggestion
+# CA1510: Use ArgumentNullException throw helper
+dotnet_diagnostic.CA1510.severity = suggestion
+# CA1511: Use ArgumentException throw helper
+dotnet_diagnostic.CA1511.severity = suggestion
+# CA1512: Use ArgumentOutOfRangeException throw helper
+dotnet_diagnostic.CA1512.severity = suggestion
+# CA1513: Use ObjectDisposedException throw helper
+dotnet_diagnostic.CA1513.severity = suggestion
+# CA1802: Use literals where appropriate
+dotnet_diagnostic.CA1802.severity = suggestion
+# CA1805: Do not initialize unnecessarily
+dotnet_diagnostic.CA1805.severity = suggestion
+# CA1810: Do not initialize unnecessarily
+dotnet_diagnostic.CA1810.severity = suggestion
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = suggestion
+# CA1823: Avoid zero-length array allocations
+dotnet_diagnostic.CA1825.severity = suggestion
+# CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
+dotnet_diagnostic.CA1826.severity = suggestion
+# CA1827: Do not use Count() or LongCount() when Any() can be used
+dotnet_diagnostic.CA1827.severity = suggestion
+# CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.CA1829.severity = suggestion
+# CA1831: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1831.severity = suggestion
+# CA1832: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1832.severity = suggestion
+# CA1833: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+dotnet_diagnostic.CA1833.severity = suggestion
+# CA1834: Consider using 'StringBuilder.Append(char)' when applicable
+dotnet_diagnostic.CA1834.severity = suggestion
+# CA1835: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+dotnet_diagnostic.CA1835.severity = suggestion
+# CA1837: Use 'Environment.ProcessId'
+dotnet_diagnostic.CA1837.severity = suggestion
+# CA1838: Avoid 'StringBuilder' parameters for P/Invokes
+dotnet_diagnostic.CA1838.severity = suggestion
+# CA1841: Prefer Dictionary.Contains methods
+dotnet_diagnostic.CA1841.severity = suggestion
+# CA1844: Provide memory-based overrides of async methods when subclassing 'Stream'
+dotnet_diagnostic.CA1844.severity = suggestion
+# CA1845: Use span-based 'string.Concat'
+dotnet_diagnostic.CA1845.severity = suggestion
+# CA1846: Prefer AsSpan over Substring
+dotnet_diagnostic.CA1846.severity = suggestion
+# CA1847: Use string.Contains(char) instead of string.Contains(string) with single characters
+dotnet_diagnostic.CA1847.severity = suggestion
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = suggestion
+# CA1854: Prefer the IDictionary.TryGetValue(TKey, out TValue) method
+dotnet_diagnostic.CA1854.severity = suggestion
+# CA1855: Prefer 'Clear' over 'Fill'
+dotnet_diagnostic.CA1855.severity = suggestion
+# CA1856: Incorrect usage of ConstantExpected attribute
+dotnet_diagnostic.CA1856.severity = suggestion
+# CA1857: A constant is expected for the parameter
+dotnet_diagnostic.CA1857.severity = suggestion
+# CA1858: Use 'StartsWith' instead of 'IndexOf'
+dotnet_diagnostic.CA1858.severity = suggestion
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = suggestion
+# CA2008: Do not create tasks without passing a TaskScheduler
+dotnet_diagnostic.CA2008.severity = suggestion
+# CA2012: Use ValueTask correctly
+dotnet_diagnostic.CA2012.severity = suggestion
+# CA2022: Avoid inexact read with `Stream.Read`
+dotnet_diagnostic.CA2022.severity = suggestion
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = suggestion
+# CA2249: Use string.Contains instead of string.IndexOf to improve readability.
+dotnet_diagnostic.CA2249.severity = suggestion
+# IDE0005: Remove unnecessary usings
+dotnet_diagnostic.IDE0005.severity = suggestion
+# IDE0020: Use pattern matching to avoid is check followed by a cast (with variable)
+dotnet_diagnostic.IDE0020.severity = suggestion
+# IDE0029: Use coalesce expression (non-nullable types)
+dotnet_diagnostic.IDE0029.severity = suggestion
+# IDE0030: Use coalesce expression (nullable types)
+dotnet_diagnostic.IDE0030.severity = suggestion
+# IDE0031: Use null propagation
+dotnet_diagnostic.IDE0031.severity = suggestion
+# IDE0038: Use pattern matching to avoid is check followed by a cast (without variable)
+dotnet_diagnostic.IDE0038.severity = suggestion
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = suggestion
+# IDE0051: Remove unused private members
+dotnet_diagnostic.IDE0051.severity = suggestion
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = suggestion
+# IDE0060: Remove unused parameters
+dotnet_diagnostic.IDE0060.severity = suggestion
+# IDE0062: Make local function static
+dotnet_diagnostic.IDE0062.severity = suggestion
+# IDE0200: Lambda expression can be removed
+dotnet_diagnostic.IDE0200.severity = suggestion
+
+# CA2016: Forward the 'CancellationToken' parameter to methods that take one
+dotnet_diagnostic.CA2016.severity = suggestion
+
+# Defaults for content in the shared src/ and shared runtime dir
+
+[{**/Shared/runtime/**.{cs,vb},src/Shared/test/Shared.Tests/runtime/**.{cs,vb},**/microsoft.extensions.hostfactoryresolver.sources/**.{cs,vb}}]
+# CA1822: Make member static
+dotnet_diagnostic.CA1822.severity = silent
+# IDE0011: Use braces
+dotnet_diagnostic.IDE0011.severity = silent
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = silent
+# IDE0060: Remove unused parameters
+dotnet_diagnostic.IDE0060.severity = silent
+# IDE0062: Make local function static
+dotnet_diagnostic.IDE0062.severity = silent
+# IDE0161: Convert to file-scoped namespace
+dotnet_diagnostic.IDE0161.severity = silent
+
+[{**/Shared/**.cs,**/microsoft.extensions.hostfactoryresolver.sources/**.{cs,vb}}]
+# IDE0005: Remove unused usings. Ignore for shared src files since imports for those depend on the projects in which they are included.
+dotnet_diagnostic.IDE0005.severity = silent
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+
+# Verify settings
+[*.{received,verified}.{txt,xml,json}]
+charset = "utf-8-bom"
+end_of_line = lf
+indent_size = unset
+indent_style = unset
+insert_final_newline = false
+tab_width = unset
+trim_trailing_whitespace = false

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -85,9 +85,8 @@
     <PackageReference Update="Moryx.Launcher" Version="$(MoryxVersion)" />
 
     <!-- MORYX Simulation -->
-    <PackageReference Update="Moryx.Simulation" Version="$(MoryxVersion)" />
     <PackageReference Update="Moryx.Drivers.Simulation" Version="$(MoryxVersion)" />
-    <PackageReference Update="Moryx.Simulation.Simulator" Version="$(MoryxVersion)" />
+    <PackageReference Update="Moryx.ControlSystem.Simulator" Version="$(MoryxVersion)" />
 
     <!-- MORYX FactoryMonitor-->
     <PackageReference Update="Moryx.FactoryMonitor.Web" Version="$(MoryxVersion)" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,7 +3,7 @@
 
   <!-- Central package version management -->
   <PropertyGroup>
-    <MoryxVersion>8.*</MoryxVersion>
+    <MoryxVersion>10.*-future.*</MoryxVersion>
   </PropertyGroup>
 
   <!-- Package versions for package references across all projects -->

--- a/MyApplication.sln
+++ b/MyApplication.sln
@@ -7,6 +7,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MyApplication.App", "src\My
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{1A406070-54A2-4468-92D1-5F7DB32F4560}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		NuGet.Config = NuGet.Config

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageRestore>
     <!-- Allow NuGet to download missing packages -->
@@ -12,6 +12,5 @@
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="MORYX Open Source CI Packages" value="https://www.myget.org/F/moryx-oss-ci/api/v3/index.json" />
-    <add key="MORYX Commercial Packages" value="https://www.myget.org/F/moryx/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/MyApplication.App/Controllers/MyFacadeController.cs
+++ b/src/MyApplication.App/Controllers/MyFacadeController.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Resources;
 
 namespace MyApplication.App;

--- a/src/MyApplication.App/Controllers/MyFacadeController.cs
+++ b/src/MyApplication.App/Controllers/MyFacadeController.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Resources;

--- a/src/MyApplication.App/Controllers/MyFacadeController.cs
+++ b/src/MyApplication.App/Controllers/MyFacadeController.cs
@@ -3,7 +3,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Moryx.AbstractionLayer.Resources;
 
-namespace MyApplication.App;
+namespace MyApplication.App.Controllers;
 
 [ApiController, Route("test/")]
 public class MyFacadeController(IResourceManagement facade) : ControllerBase

--- a/src/MyApplication.App/ExamplePolicyProvider.cs
+++ b/src/MyApplication.App/ExamplePolicyProvider.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;

--- a/src/MyApplication.App/ExamplePolicyProvider.cs
+++ b/src/MyApplication.App/ExamplePolicyProvider.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.AspNetCore.Authorization;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Options;
 using System.Threading.Tasks;
 

--- a/src/MyApplication.App/MyApplication.App.csproj
+++ b/src/MyApplication.App/MyApplication.App.csproj
@@ -79,9 +79,7 @@
     <PackageReference Include="Moryx.ProcessData.Adapter.ResourceManagement" />
     <PackageReference Include="Moryx.ProcessData.Adapter.NotificationPublisher" />
     <PackageReference Include="Moryx.ProcessData.Endpoints" />    
-    <!--<PackageReference Include="Moryx.Analytics.Web" />-->
-
-    <PackageReference Include="Wibu.CodeMeter" Version="7.21.0" />
+    <PackageReference Include="Moryx.Analytics.Web" />
   </ItemGroup>
 
   <ItemGroup>
@@ -97,25 +95,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <Compile Remove="$(UserProfile)\.nuget\packages\**\*.WibuCmRaU" />
-  </ItemGroup>
- 
-	<ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-		<None Include="$(UserProfile)\.nuget\packages\**\*.WibuCmRaU">
-			<Link>%(Filename)%(Extension)</Link>
-		</None>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(OS)' == 'Unix'">
-		<Compile Remove="/root/.nuget/packages/**/*.WibuCmRaU" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(OS)' == 'Unix'">
-		<None Include="/root/.nuget/packages/**/*.WibuCmRaU">
-			<Link>%(Filename)%(Extension)</Link>
-		</None>
-	</ItemGroup>
 
 </Project>

--- a/src/MyApplication.App/MyApplication.App.csproj
+++ b/src/MyApplication.App/MyApplication.App.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -66,8 +66,8 @@
     <PackageReference Include="Moryx.Launcher" />
 
     <!-- MORYX Simulation -->
-    <PackageReference Include="Moryx.Simulation" />
-    <PackageReference Include="Moryx.Simulation.Simulator" />
+    <PackageReference Include="Moryx.ControlSystem" />
+    <PackageReference Include="Moryx.ControlSystem.Simulator" />
 
     <!-- MORYX Factory Monitor -->
     <PackageReference Include="Moryx.FactoryMonitor.Web" />

--- a/src/MyApplication.App/Program.cs
+++ b/src/MyApplication.App/Program.cs
@@ -1,11 +1,9 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Moryx.Asp.Integration;
 using Moryx.Launcher;
 using Moryx.Model;
 using Moryx.Runtime.Kernel;

--- a/src/MyApplication.App/Program.cs
+++ b/src/MyApplication.App/Program.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -41,7 +43,6 @@ services.Configure<RequestLocalizationOptions>(options =>
     options.SupportedCultures = supportedCultures;
     options.SupportedUICultures = supportedCultures;
 });
-
 
 services.AddCors(options =>
 {

--- a/src/MyApplication.App/Program.cs
+++ b/src/MyApplication.App/Program.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;

--- a/src/MyApplication.App/Program.cs
+++ b/src/MyApplication.App/Program.cs
@@ -85,7 +85,9 @@ app.UseHttpsRedirection();
 app.UseRouting();
 
 if (env.IsDevelopment())
+{
     app.UseCors("CorsPolicy");
+}
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/src/MyApplication.ControlSystem/CellSelector/MyCellSelector.cs
+++ b/src/MyApplication.ControlSystem/CellSelector/MyCellSelector.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using System;
 using System.Collections.Generic;

--- a/src/MyApplication.ControlSystem/CellSelector/MyCellSelector.cs
+++ b/src/MyApplication.ControlSystem/CellSelector/MyCellSelector.cs
@@ -1,4 +1,6 @@
-﻿using System;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Moryx.AbstractionLayer;

--- a/src/MyApplication.ControlSystem/CellSelector/MyCellSelector.cs
+++ b/src/MyApplication.ControlSystem/CellSelector/MyCellSelector.cs
@@ -26,6 +26,6 @@ public class MyCellSelector : CellSelectorBase<MyCellSelectorConfig>
         // Random based load balancer
         var random = new Random();
         var cells = availableCells.OrderBy(cell => random.Next());
-        return cells.ToList();
+        return [.. cells];
     }
 }

--- a/src/MyApplication.ControlSystem/CellSelector/MyCellSelectorConfig.cs
+++ b/src/MyApplication.ControlSystem/CellSelector/MyCellSelectorConfig.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.ControlSystem.Cells;
 

--- a/src/MyApplication.ControlSystem/CellSelector/MyCellSelectorConfig.cs
+++ b/src/MyApplication.ControlSystem/CellSelector/MyCellSelectorConfig.cs
@@ -1,4 +1,6 @@
-﻿using Moryx.ControlSystem.Cells;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using Moryx.ControlSystem.Cells;
 
 namespace MyApplication.ControlSystem.CellSelector;
 

--- a/src/MyApplication.ControlSystem/SetupTriggers/MySetupTrigger.cs
+++ b/src/MyApplication.ControlSystem/SetupTriggers/MySetupTrigger.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using System;
 using System.Collections.Generic;

--- a/src/MyApplication.ControlSystem/SetupTriggers/MySetupTrigger.cs
+++ b/src/MyApplication.ControlSystem/SetupTriggers/MySetupTrigger.cs
@@ -5,7 +5,6 @@ using Moryx.Container;
 using Moryx.ControlSystem.Setups;
 using Moryx.Modules;
 using Moryx.Workplans;
-using MyApplication.Capabilities;
 
 namespace MyApplication.ControlSystem.SetupTriggers;
 

--- a/src/MyApplication.ControlSystem/SetupTriggers/MySetupTrigger.cs
+++ b/src/MyApplication.ControlSystem/SetupTriggers/MySetupTrigger.cs
@@ -19,8 +19,6 @@ public class MySetupTrigger : SetupTriggerBase<MySetupTriggerConfig>
     public override SetupEvaluation Evaluate(IProductRecipe recipe)
     {
         return true;
-        return SetupClassification.MaterialChange;
-        return SetupEvaluation.Provide(new SomeCapabilities());
     }
 
     public override IReadOnlyList<IWorkplanStep> CreateSteps(IProductRecipe recipe)

--- a/src/MyApplication.ControlSystem/SetupTriggers/MySetupTrigger.cs
+++ b/src/MyApplication.ControlSystem/SetupTriggers/MySetupTrigger.cs
@@ -1,4 +1,6 @@
-﻿using System;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using System;
 using System.Collections.Generic;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Container;

--- a/src/MyApplication.ControlSystem/SetupTriggers/MySetupTriggerConfig.cs
+++ b/src/MyApplication.ControlSystem/SetupTriggers/MySetupTriggerConfig.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.ControlSystem.Setups;
 

--- a/src/MyApplication.ControlSystem/SetupTriggers/MySetupTriggerConfig.cs
+++ b/src/MyApplication.ControlSystem/SetupTriggers/MySetupTriggerConfig.cs
@@ -1,4 +1,6 @@
-﻿using Moryx.ControlSystem.Setups;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using Moryx.ControlSystem.Setups;
 
 namespace MyApplication.ControlSystem.SetupTriggers;
 

--- a/src/MyApplication.Orders/MyApplicationProductAssignment.cs
+++ b/src/MyApplication.Orders/MyApplicationProductAssignment.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;

--- a/src/MyApplication.Orders/MyApplicationProductAssignment.cs
+++ b/src/MyApplication.Orders/MyApplicationProductAssignment.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moryx.AbstractionLayer.Products;
 using Moryx.Container;

--- a/src/MyApplication.Orders/MyApplicationProductAssignment.cs
+++ b/src/MyApplication.Orders/MyApplicationProductAssignment.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.Logging;
 using Moryx.AbstractionLayer.Products;
 using Moryx.Container;
-using Moryx.Logging;
 using Moryx.Orders;
 using Moryx.Orders.Assignment;
 

--- a/src/MyApplication.Orders/MyApplicationRecipeAssignment.cs
+++ b/src/MyApplication.Orders/MyApplicationRecipeAssignment.cs
@@ -1,4 +1,5 @@
-﻿using System;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Moryx.AbstractionLayer.Recipes;

--- a/src/MyApplication.Orders/MyApplicationRecipeAssignment.cs
+++ b/src/MyApplication.Orders/MyApplicationRecipeAssignment.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/MyApplication.Products/Importer/MyApplicationImportParameters.cs
+++ b/src/MyApplication.Products/Importer/MyApplicationImportParameters.cs
@@ -1,6 +1,6 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 
-namespace MyApplication.Products;
+namespace MyApplication.Products.Importer;
 
 /// <summary>
 /// Parameters for the <see cref="MyApplicationProductImporter"/>

--- a/src/MyApplication.Products/Importer/MyApplicationImportParameters.cs
+++ b/src/MyApplication.Products/Importer/MyApplicationImportParameters.cs
@@ -1,4 +1,5 @@
-﻿
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 namespace MyApplication.Products;
 
 /// <summary>

--- a/src/MyApplication.Products/Importer/MyApplicationImportParameters.cs
+++ b/src/MyApplication.Products/Importer/MyApplicationImportParameters.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 namespace MyApplication.Products.Importer;
 

--- a/src/MyApplication.Products/Importer/MyApplicationProductImporter.cs
+++ b/src/MyApplication.Products/Importer/MyApplicationProductImporter.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Moryx.AbstractionLayer.Products;
 using Moryx.Container;
@@ -13,7 +15,7 @@ namespace MyApplication.Products;
 /// </summary>
 [ExpectedConfig(typeof(MyApplicationProductImporterConfig))]
 [Plugin(LifeCycle.Transient, typeof(IProductImporter), Name = nameof(MyApplicationProductImporter))]
-public  class MyApplicationProductImporter :  ProductImporterBase<MyApplicationProductImporterConfig, MyApplicationImportParameters>, ILoggingComponent
+public class MyApplicationProductImporter : ProductImporterBase<MyApplicationProductImporterConfig, MyApplicationImportParameters>, ILoggingComponent
 {
     /// <inheritdoc />
     public IModuleLogger Logger { get; set; }

--- a/src/MyApplication.Products/Importer/MyApplicationProductImporter.cs
+++ b/src/MyApplication.Products/Importer/MyApplicationProductImporter.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/MyApplication.Products/Importer/MyApplicationProductImporter.cs
+++ b/src/MyApplication.Products/Importer/MyApplicationProductImporter.cs
@@ -8,7 +8,7 @@ using Moryx.Logging;
 using Moryx.Modules;
 using Moryx.Products.Management;
 
-namespace MyApplication.Products;
+namespace MyApplication.Products.Importer;
 
 /// <summary>
 /// Imports products for MyApplication

--- a/src/MyApplication.Products/Importer/MyApplicationProductImporterConfig.cs
+++ b/src/MyApplication.Products/Importer/MyApplicationProductImporterConfig.cs
@@ -1,4 +1,6 @@
-﻿using Moryx.AbstractionLayer.Products;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using Moryx.AbstractionLayer.Products;
 
 namespace MyApplication.Products;
 

--- a/src/MyApplication.Products/Importer/MyApplicationProductImporterConfig.cs
+++ b/src/MyApplication.Products/Importer/MyApplicationProductImporterConfig.cs
@@ -2,7 +2,7 @@
 
 using Moryx.AbstractionLayer.Products;
 
-namespace MyApplication.Products;
+namespace MyApplication.Products.Importer;
 
 /// <summary>
 /// Config for the <see cref="MyApplicationProductImporter"/>

--- a/src/MyApplication.Products/Importer/MyApplicationProductImporterConfig.cs
+++ b/src/MyApplication.Products/Importer/MyApplicationProductImporterConfig.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Products;
 

--- a/src/MyApplication.Resources/MyResource/MyResource.cs
+++ b/src/MyApplication.Resources/MyResource/MyResource.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Resources;
 

--- a/src/MyApplication.Resources/MyResource/MyResource.cs
+++ b/src/MyApplication.Resources/MyResource/MyResource.cs
@@ -1,7 +1,6 @@
-using System.ComponentModel;
-using System.Runtime.Serialization;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using Moryx.AbstractionLayer.Resources;
-using Moryx.Serialization;
 
 namespace MyApplication.Resources.MyResource;
 

--- a/src/MyApplication.Resources/MyResource/MyResource.cs
+++ b/src/MyApplication.Resources/MyResource/MyResource.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.Serialization;
@@ -8,10 +8,6 @@ namespace MyApplication.Resources.MyResource;
 [ResourceRegistration] // Only necessary for dependency injection like logging or parallel operations
 public class MyResource : Resource
 {
-    [DataMember, EntrySerialize]
-    [Description("Configurable value")]
-    public int Value { get; set; }
-
     protected override void OnInitialize()
     {
         base.OnInitialize();
@@ -21,5 +17,4 @@ public class MyResource : Resource
     {
         base.OnDispose();
     }
-
 }

--- a/src/MyApplication.Resources/SimulatedInOutDriver.cs
+++ b/src/MyApplication.Resources/SimulatedInOutDriver.cs
@@ -1,11 +1,6 @@
 using Moryx.AbstractionLayer;
 using Moryx.Drivers.Simulation.InOutDriver;
 using Moryx.Simulation;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MyApplication.Resources;
 

--- a/src/MyApplication.Resources/SimulatedInOutDriver.cs
+++ b/src/MyApplication.Resources/SimulatedInOutDriver.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using Moryx.AbstractionLayer;
 using Moryx.Drivers.Simulation.InOutDriver;
 using Moryx.Simulation;
@@ -25,8 +27,8 @@ public class SimulatedInOutDriver : SimulatedInOutDriver<object, object>
             else
             {
                 SimulatedState = SimulationState.Idle;
+            }
         }
-    }
     }
 
     public override void Result(SimulationResult result)

--- a/src/MyApplication.Resources/SimulatedInOutDriver.cs
+++ b/src/MyApplication.Resources/SimulatedInOutDriver.cs
@@ -1,4 +1,4 @@
-﻿using Moryx.AbstractionLayer;
+using Moryx.AbstractionLayer;
 using Moryx.Drivers.Simulation.InOutDriver;
 using Moryx.Simulation;
 using System;

--- a/src/MyApplication.Resources/SimulatedInOutDriver.cs
+++ b/src/MyApplication.Resources/SimulatedInOutDriver.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer;
 using Moryx.ControlSystem.Simulation;

--- a/src/MyApplication.Resources/SimulatedInOutDriver.cs
+++ b/src/MyApplication.Resources/SimulatedInOutDriver.cs
@@ -1,8 +1,8 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 
 using Moryx.AbstractionLayer;
+using Moryx.ControlSystem.Simulation;
 using Moryx.Drivers.Simulation.InOutDriver;
-using Moryx.Simulation;
 
 namespace MyApplication.Resources;
 

--- a/src/MyApplication.Resources/SimulatedInOutDriver.cs
+++ b/src/MyApplication.Resources/SimulatedInOutDriver.cs
@@ -19,10 +19,14 @@ public class SimulatedInOutDriver : SimulatedInOutDriver<object, object>
         if (key == "Start")
         {
             if ((bool)SimulatedOutput.Values["Start"])
+            {
                 SimulatedState = SimulationState.Executing;
+            }
             else
+            {
                 SimulatedState = SimulationState.Idle;
         }
+    }
     }
 
     public override void Result(SimulationResult result)

--- a/src/MyApplication.Resources/SomeCell.cs
+++ b/src/MyApplication.Resources/SomeCell.cs
@@ -10,13 +10,14 @@ using Moryx.ControlSystem.Activities;
 using Moryx.ControlSystem.Cells;
 using Moryx.ControlSystem.VisualInstructions;
 using Moryx.Serialization;
+using Moryx.StateMachines;
 using MyApplication.Activities.SomeStep;
 using MyApplication.Capabilities;
 
 namespace MyApplication.Resources;
 
 [ResourceRegistration] // Only necessary for dependency injection like logging or parallel operations
-public class SomeCell : Cell
+public class SomeCell : Cell, IStateContext
 {
     private Session _currentSession;
     private long _currentInstruction;
@@ -111,5 +112,10 @@ public class SomeCell : Cell
             _currentSession = result;
             PublishActivityCompleted(result);
         }
+    }
+
+    public void SetState(IState state)
+    {
+        /* Use for a resource state machine */
     }
 }

--- a/src/MyApplication.Resources/SomeCell.cs
+++ b/src/MyApplication.Resources/SomeCell.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/MyApplication.Resources/SomeCell.cs
+++ b/src/MyApplication.Resources/SomeCell.cs
@@ -74,10 +74,6 @@ public class SomeCell : Cell, IStateContext
         /* Start execution here */
     }
 
-    private void InstructionCompleted(int result, ActivityStart session)
-    {
-    }
-
     public override void ProcessAborting(IActivity affectedActivity)
     {
         // Default behavior: Clear instruction and abort execution

--- a/src/MyApplication.Resources/SomeCell.cs
+++ b/src/MyApplication.Resources/SomeCell.cs
@@ -1,10 +1,10 @@
-using System;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
 using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Drivers.InOut;
-using Moryx.AbstractionLayer.Drivers.Message;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.ControlSystem.Activities;
 using Moryx.ControlSystem.Cells;
@@ -12,7 +12,6 @@ using Moryx.ControlSystem.VisualInstructions;
 using Moryx.Serialization;
 using MyApplication.Activities.SomeStep;
 using MyApplication.Capabilities;
-using Newtonsoft.Json.Linq;
 
 namespace MyApplication.Resources;
 

--- a/src/MyApplication.Resources/SomeCell.cs
+++ b/src/MyApplication.Resources/SomeCell.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
@@ -12,15 +12,15 @@ using Moryx.ControlSystem.VisualInstructions;
 using Moryx.Serialization;
 using MyApplication.Activities.SomeStep;
 using MyApplication.Capabilities;
+using Newtonsoft.Json.Linq;
 
 namespace MyApplication.Resources;
 
 [ResourceRegistration] // Only necessary for dependency injection like logging or parallel operations
 public class SomeCell : Cell
 {
-    [DataMember, EntrySerialize]
-    [Description("Configured value for the capabilities")]
-    public int Value { get; set; }
+    private Session _currentSession;
+    private long _currentInstruction;
 
     [ResourceReference(ResourceRelationType.Driver)]
     public IInOutDriver<object, object> Driver { get; set; }
@@ -28,13 +28,13 @@ public class SomeCell : Cell
     [ResourceReference(ResourceRelationType.Extension)]
     public IVisualInstructor VisualInstructor { get; set; }
 
-    private Session _currentSession;
-    private long _currentInstruction;
+    [DataMember, EntrySerialize]
+    [Description("Configured value for the capabilities")]
+    public int Value { get; set; }
 
     protected override void OnInitialize()
     {
         base.OnInitialize();
-
         Capabilities = new SomeCapabilities { Value = Value };
 
         if (Driver != null)
@@ -58,10 +58,6 @@ public class SomeCell : Cell
 
     public override IEnumerable<Session> ControlSystemAttached()
     {
-        // Publish worker support session if instructor is configured instead of driver
-        if (VisualInstructor != null && Driver == null)
-            yield return _currentSession = Session.StartSession(ActivityClassification.Production, ReadyToWorkType.Push);
-
         yield break;
     }
 
@@ -72,28 +68,11 @@ public class SomeCell : Cell
 
     public override void StartActivity(ActivityStart activityStart)
     {
-        _currentSession = activityStart;
-        switch (activityStart.Activity)
-        {
-            case SomeActivity activity:
-                /* Start execution via driver */
-                if (VisualInstructor != null)
-                {
-                    VisualInstructor.Execute(Name, activityStart, InstructionCompleted);
-                }
-                else if (Driver != null)
-                {
-                    Driver.Output["Start"] = true;
-                }
-                break;
-        }
+        /* Start execution here */
     }
 
     private void InstructionCompleted(int result, ActivityStart session)
     {
-        var completed = session.CreateResult(result);
-        _currentSession = completed;
-        PublishActivityCompleted(completed);
     }
 
     public override void ProcessAborting(IActivity affectedActivity)
@@ -113,18 +92,6 @@ public class SomeCell : Cell
 
     public override void SequenceCompleted(SequenceCompleted completed)
     {
-        _currentSession = completed;
-
-        if (Driver == null)
-        {
-            var rtw = Session.StartSession(ActivityClassification.Production, ReadyToWorkType.Push);
-            _currentSession = rtw;
-            PublishReadyToWork(rtw);
-        }
-        else
-        {
-            Driver.Output["Start"] = false;
-        }
     }
 
     private void OnInputChanged(object sender, InputChangedEventArgs args)

--- a/src/MyApplication.Resources/SomeCell.cs
+++ b/src/MyApplication.Resources/SomeCell.cs
@@ -37,7 +37,9 @@ public class SomeCell : Cell
         Capabilities = new SomeCapabilities { Value = Value };
 
         if (Driver != null)
+        {
             Driver.Input.InputChanged += OnInputChanged;
+        }
     }
 
     protected override void OnStart()
@@ -82,7 +84,9 @@ public class SomeCell : Cell
             // Clear driver and/or instructor
             VisualInstructor?.Clear(_currentInstruction);
             if (Driver != null)
+            {
                 Driver.Output["Start"] = false;
+            }
 
             // Report current activity as failed
             activityStart.CreateResult((int)SomeActivityResults.Failed);

--- a/src/MyApplication.Resources/SpecificState.cs
+++ b/src/MyApplication.Resources/SpecificState.cs
@@ -1,4 +1,4 @@
-﻿using Moryx.StateMachines;
+using Moryx.StateMachines;
 
 namespace MyApplication.Resources.SomeCell.States
 {

--- a/src/MyApplication.Resources/SpecificState.cs
+++ b/src/MyApplication.Resources/SpecificState.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 namespace MyApplication.Resources
 {

--- a/src/MyApplication.Resources/SpecificState.cs
+++ b/src/MyApplication.Resources/SpecificState.cs
@@ -1,12 +1,11 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-namespace MyApplication.Resources
+namespace MyApplication.Resources;
+
+internal class SpecificState : SomeStateBase
 {
-    internal class SpecificState : SomeStateBase
+    public SpecificState(SomeCell context, StateMap stateMap) : base(context, stateMap)
     {
-        public SpecificState(SomeCell context, StateMap stateMap) : base(context, stateMap)
-        {
-        }
     }
 }

--- a/src/MyApplication.Resources/SpecificState.cs
+++ b/src/MyApplication.Resources/SpecificState.cs
@@ -1,6 +1,6 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 
-namespace MyApplication.Resources.SomeCell.States
+namespace MyApplication.Resources
 {
     internal class SpecificState : SomeStateBase
     {

--- a/src/MyApplication.Resources/SpecificState.cs
+++ b/src/MyApplication.Resources/SpecificState.cs
@@ -3,9 +3,6 @@
 
 namespace MyApplication.Resources;
 
-internal class SpecificState : SomeStateBase
+internal class SpecificState(SomeCell context, Moryx.StateMachines.StateBase.StateMap stateMap) : SomeStateBase(context, stateMap)
 {
-    public SpecificState(SomeCell context, StateMap stateMap) : base(context, stateMap)
-    {
-    }
 }

--- a/src/MyApplication.Resources/SpecificState.cs
+++ b/src/MyApplication.Resources/SpecificState.cs
@@ -1,4 +1,4 @@
-using Moryx.StateMachines;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
 
 namespace MyApplication.Resources.SomeCell.States
 {

--- a/src/MyApplication.Resources/StateBase.cs
+++ b/src/MyApplication.Resources/StateBase.cs
@@ -2,7 +2,7 @@
 
 using Moryx.StateMachines;
 
-namespace MyApplication.Resources.SomeCell.States
+namespace MyApplication.Resources
 {
     internal abstract class SomeStateBase : StateBase<SomeCell>
     {

--- a/src/MyApplication.Resources/StateBase.cs
+++ b/src/MyApplication.Resources/StateBase.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using Moryx.StateMachines;
 
 namespace MyApplication.Resources.SomeCell.States

--- a/src/MyApplication.Resources/StateBase.cs
+++ b/src/MyApplication.Resources/StateBase.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.StateMachines;
 

--- a/src/MyApplication.Resources/StateBase.cs
+++ b/src/MyApplication.Resources/StateBase.cs
@@ -1,11 +1,9 @@
-﻿using Moryx.StateMachines;
+using Moryx.StateMachines;
 
 namespace MyApplication.Resources.SomeCell.States
 {
     internal abstract class SomeStateBase : StateBase<SomeCell>
     {
-
-        
         public SomeStateBase(SomeCell context, StateMap stateMap) : base(context, stateMap)
         {
         }

--- a/src/MyApplication.Resources/StateBase.cs
+++ b/src/MyApplication.Resources/StateBase.cs
@@ -5,9 +5,6 @@ using Moryx.StateMachines;
 
 namespace MyApplication.Resources;
 
-internal abstract class SomeStateBase : StateBase<SomeCell>
+internal abstract class SomeStateBase(SomeCell context, StateBase.StateMap stateMap) : StateBase<SomeCell>(context, stateMap)
 {
-    public SomeStateBase(SomeCell context, StateMap stateMap) : base(context, stateMap)
-    {
-    }
 }

--- a/src/MyApplication.Resources/StateBase.cs
+++ b/src/MyApplication.Resources/StateBase.cs
@@ -3,12 +3,11 @@
 
 using Moryx.StateMachines;
 
-namespace MyApplication.Resources
+namespace MyApplication.Resources;
+
+internal abstract class SomeStateBase : StateBase<SomeCell>
 {
-    internal abstract class SomeStateBase : StateBase<SomeCell>
+    public SomeStateBase(SomeCell context, StateMap stateMap) : base(context, stateMap)
     {
-        public SomeStateBase(SomeCell context, StateMap stateMap) : base(context, stateMap)
-        {
-        }
     }
 }

--- a/src/MyApplication/Activities/SomeStep/SomeActivity.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeActivity.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Capabilities;

--- a/src/MyApplication/Activities/SomeStep/SomeActivity.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeActivity.cs
@@ -5,23 +5,22 @@ using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Capabilities;
 using MyApplication.Capabilities;
 
-namespace MyApplication.Activities.SomeStep
+namespace MyApplication.Activities.SomeStep;
+
+[ActivityResults(typeof(SomeActivityResults))]
+public class SomeActivity : Activity<SomeParameters>
 {
-    [ActivityResults(typeof(SomeActivityResults))]
-    public class SomeActivity : Activity<SomeParameters>
+    public override ProcessRequirement ProcessRequirement => ProcessRequirement.NotRequired;
+
+    public override ICapabilities RequiredCapabilities => new SomeCapabilities();
+
+    protected override ActivityResult CreateResult(long resultNumber)
     {
-        public override ProcessRequirement ProcessRequirement => ProcessRequirement.NotRequired;
+        return ActivityResult.Create((SomeActivityResults)resultNumber);
+    }
 
-        public override ICapabilities RequiredCapabilities => new SomeCapabilities();
-
-        protected override ActivityResult CreateResult(long resultNumber)
-        {
-            return ActivityResult.Create((SomeActivityResults)resultNumber);
-        }
-
-        protected override ActivityResult CreateFailureResult()
-        {
-            return ActivityResult.Create(SomeActivityResults.Failed);
-        }
+    protected override ActivityResult CreateFailureResult()
+    {
+        return ActivityResult.Create(SomeActivityResults.Failed);
     }
 }

--- a/src/MyApplication/Activities/SomeStep/SomeActivity.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeActivity.cs
@@ -1,4 +1,4 @@
-﻿using Moryx.AbstractionLayer;
+using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Capabilities;
 using MyApplication.Capabilities;
 

--- a/src/MyApplication/Activities/SomeStep/SomeActivity.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeActivity.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Capabilities;
 using MyApplication.Capabilities;

--- a/src/MyApplication/Activities/SomeStep/SomeActivityResults.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeActivityResults.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using System.ComponentModel.DataAnnotations;
 
 namespace MyApplication.Activities.SomeStep;

--- a/src/MyApplication/Activities/SomeStep/SomeActivityResults.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeActivityResults.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using System.ComponentModel.DataAnnotations;
 

--- a/src/MyApplication/Activities/SomeStep/SomeActivityResults.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeActivityResults.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace MyApplication.Activities.SomeStep;
 

--- a/src/MyApplication/Activities/SomeStep/SomeParameters.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeParameters.cs
@@ -1,4 +1,4 @@
-﻿using Moryx.AbstractionLayer;
+using Moryx.AbstractionLayer;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.ControlSystem.VisualInstructions;
 using Moryx.Serialization;
@@ -7,26 +7,7 @@ namespace MyApplication.Activities.SomeStep;
 
 public class SomeParameters : VisualInstructionParameters
 {
-    /// <summary>
-    /// Example of a parameter value as user input
-    /// </summary>
-    [EntrySerialize]
-    public int UserInput { get; set; }
-
-    /// <summary>
-    /// Example of a parameter value as product input
-    /// </summary>
-    [EntrySerialize(EntrySerializeMode.Never)] // Redundant with the explicit declaration, just as a hint
-    public int TwinAttribute { get; set; }
-
     protected override void Populate(IProcess process, Parameters instance)
     {
-        base.Populate(process, instance);
-
-        var parameters = (SomeParameters)instance;
-        parameters.UserInput = UserInput; // Simply copy to activity instance
-
-        var recipe = (IProductRecipe)process.Recipe;
-        parameters.TwinAttribute = recipe.Product.Name.Length;
     }
 }

--- a/src/MyApplication/Activities/SomeStep/SomeParameters.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeParameters.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using Moryx.AbstractionLayer;
 using Moryx.ControlSystem.VisualInstructions;
 

--- a/src/MyApplication/Activities/SomeStep/SomeParameters.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeParameters.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer;
 using Moryx.ControlSystem.VisualInstructions;

--- a/src/MyApplication/Activities/SomeStep/SomeParameters.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeParameters.cs
@@ -1,7 +1,5 @@
 using Moryx.AbstractionLayer;
-using Moryx.AbstractionLayer.Recipes;
 using Moryx.ControlSystem.VisualInstructions;
-using Moryx.Serialization;
 
 namespace MyApplication.Activities.SomeStep;
 

--- a/src/MyApplication/Activities/SomeStep/SomeTask.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeTask.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using Moryx.AbstractionLayer;
 using System.ComponentModel.DataAnnotations;
 

--- a/src/MyApplication/Activities/SomeStep/SomeTask.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeTask.cs
@@ -1,4 +1,4 @@
-﻿using Moryx.AbstractionLayer;
+using Moryx.AbstractionLayer;
 using System.ComponentModel.DataAnnotations;
 
 namespace MyApplication.Activities.SomeStep;

--- a/src/MyApplication/Activities/SomeStep/SomeTask.cs
+++ b/src/MyApplication/Activities/SomeStep/SomeTask.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer;
 using System.ComponentModel.DataAnnotations;

--- a/src/MyApplication/Capabilities/SomeCapabilities.cs
+++ b/src/MyApplication/Capabilities/SomeCapabilities.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using Moryx.AbstractionLayer.Capabilities;
 
 namespace MyApplication.Capabilities;

--- a/src/MyApplication/Capabilities/SomeCapabilities.cs
+++ b/src/MyApplication/Capabilities/SomeCapabilities.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Capabilities;
 

--- a/src/MyApplication/Capabilities/SomeCapabilities.cs
+++ b/src/MyApplication/Capabilities/SomeCapabilities.cs
@@ -9,11 +9,15 @@ public class SomeCapabilities : CapabilitiesBase
     protected override bool ProvidedBy(ICapabilities provided)
     {
         var providedSome = provided as SomeCapabilities;
-        if (providedSome== null)
+        if (providedSome == null)
+        {
             return false;
+        }
 
         if (providedSome.Value < Value) // Provided must be greater or equal
+        {
             return false;
+        }
 
         return true;
 

--- a/src/MyApplication/Capabilities/SomeCapabilities.cs
+++ b/src/MyApplication/Capabilities/SomeCapabilities.cs
@@ -1,4 +1,4 @@
-﻿using Moryx.AbstractionLayer.Capabilities;
+using Moryx.AbstractionLayer.Capabilities;
 
 namespace MyApplication.Capabilities;
 
@@ -9,12 +9,13 @@ public class SomeCapabilities : CapabilitiesBase
     protected override bool ProvidedBy(ICapabilities provided)
     {
         var providedSome = provided as SomeCapabilities;
-        if (providedSome == null)
+        if (providedSome== null)
             return false;
 
         if (providedSome.Value < Value) // Provided must be greater or equal
             return false;
 
         return true;
+
     }
 }

--- a/src/MyApplication/Products/MyProductInstance.cs
+++ b/src/MyApplication/Products/MyProductInstance.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Products;
 using System;

--- a/src/MyApplication/Products/MyProductInstance.cs
+++ b/src/MyApplication/Products/MyProductInstance.cs
@@ -1,4 +1,6 @@
-﻿using Moryx.AbstractionLayer.Products;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using Moryx.AbstractionLayer.Products;
 using System;
 
 namespace MyApplication.Products;

--- a/src/MyApplication/Products/MyProductType.cs
+++ b/src/MyApplication/Products/MyProductType.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Products;
 using System.ComponentModel.DataAnnotations;

--- a/src/MyApplication/Products/MyProductType.cs
+++ b/src/MyApplication/Products/MyProductType.cs
@@ -1,4 +1,6 @@
-﻿using Moryx.AbstractionLayer.Products;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using Moryx.AbstractionLayer.Products;
 using System.ComponentModel.DataAnnotations;
 
 namespace MyApplication.Products;

--- a/src/MyApplication/Recipes/MyApplicationRecipe.cs
+++ b/src/MyApplication/Recipes/MyApplicationRecipe.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.ControlSystem.Recipes;

--- a/src/MyApplication/Recipes/MyApplicationRecipe.cs
+++ b/src/MyApplication/Recipes/MyApplicationRecipe.cs
@@ -1,3 +1,5 @@
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.ControlSystem.Recipes;
 

--- a/src/MyApplication/Recipes/MyApplicationRecipe.cs
+++ b/src/MyApplication/Recipes/MyApplicationRecipe.cs
@@ -1,4 +1,4 @@
-﻿using Moryx.AbstractionLayer.Recipes;
+using Moryx.AbstractionLayer.Recipes;
 using Moryx.ControlSystem.Recipes;
 
 namespace MyApplication.Recipes;

--- a/src/MyApplication/Resources/ISomeResource.cs
+++ b/src/MyApplication/Resources/ISomeResource.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using Moryx.AbstractionLayer.Resources;
 

--- a/src/MyApplication/Resources/ISomeResource.cs
+++ b/src/MyApplication/Resources/ISomeResource.cs
@@ -1,4 +1,6 @@
-﻿using Moryx.AbstractionLayer.Resources;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using Moryx.AbstractionLayer.Resources;
 
 namespace MyApplication.Resources;
 

--- a/src/Tests/MyApplication.Tests/MyResourceTest.cs
+++ b/src/Tests/MyApplication.Tests/MyResourceTest.cs
@@ -1,4 +1,6 @@
-﻿using MyApplication.Resources.MyResource;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using MyApplication.Resources.MyResource;
 using NUnit.Framework;
 
 namespace MyApplication.Tests;

--- a/src/Tests/MyApplication.Tests/MyResourceTest.cs
+++ b/src/Tests/MyApplication.Tests/MyResourceTest.cs
@@ -12,13 +12,9 @@ public class MyResourceTest
     public void ResourceKeepsValue()
     {
         // Arrange
-        var myResource = new MyResource();
-        myResource.Value = 42;
 
         // Act
-        myResource.Value = 1337;
 
         // Assert
-        Assert.That(1337, Is.EqualTo(myResource.Value));
     }
 }

--- a/src/Tests/MyApplication.Tests/MyResourceTest.cs
+++ b/src/Tests/MyApplication.Tests/MyResourceTest.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using MyApplication.Resources.MyResource;
 using NUnit.Framework;

--- a/src/Tests/MyApplication.Tests/SomeCellTest.cs
+++ b/src/Tests/MyApplication.Tests/SomeCellTest.cs
@@ -1,4 +1,5 @@
 // Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
 
 using MyApplication.Resources;
 using NUnit.Framework;

--- a/src/Tests/MyApplication.Tests/SomeCellTest.cs
+++ b/src/Tests/MyApplication.Tests/SomeCellTest.cs
@@ -1,4 +1,6 @@
-﻿using MyApplication.Resources;
+// Copyright (c) 2025, Phoenix Contact GmbH & Co. KG
+
+using MyApplication.Resources;
 using NUnit.Framework;
 
 namespace MyApplication.Tests;


### PR DESCRIPTION
While having a seperate branch for the ADP is not necessarily a bad idea, however the only difference atm is, that `SomeCell` and `SomeParameters` do contain a bit of example code within the machine branch, that is removed on the adp branch. 

Unless you object to this merge, I would say it is nothing that is gonna be missed when creating a cell or parameters with the CLI. Especiall since for the cell handling the process engine interactions would be better placed inside a state machine anyway 🙈