### PR TITLE
Moving UseMoryxConfiguration up in Program.cs

### DIFF
--- a/src/MyApplication.App/Program.cs
+++ b/src/MyApplication.App/Program.cs
@@ -69,6 +69,8 @@ services.AddSwaggerGen(c =>
 var app = builder.Build();
 var env = app.Environment;
 
+app.Services.UseMoryxConfigurations("Config");
+
 #region Startup Configure App
 if (env.IsDevelopment())
 {
@@ -98,8 +100,6 @@ app.MapControllers().WithMetadata(new AllowAnonymousAttribute());
 app.MapRazorPages();
 
 #endregion
-
-app.Services.UseMoryxConfigurations("Config");
 
 var moduleManager = app.Services.GetRequiredService<IModuleManager>();
 await moduleManager.StartModulesAsync();


### PR DESCRIPTION

### Summary

We encountered a bug, where after registering action filters the application would crash when it reaches the line `app.MapControllers().WithMetadata(new AllowAnonymousAttribute());`, because the MORYX configuration path is not yet set. Simply doing the configuraton earlier fixes the problem.

Because these Action Filters are required for a common internal adapter and it has no adverse effects, we would like to change it in the machine template.


### Linked Issues

<!-- 
Link to any related issues or feature requests using GitHub keywords (e.g., Closes #123).
-->

### Relevant logs and/or screenshots

<!-- 
Paste any relevant logs - please use code blocks (```) to format console output, logs, and code.

Paste images of the new features.
-->

### Breaking Changes

<!-- 
Does this PR introduce any breaking changes? If yes, describe them.
-->

### Checklist for Submitter

- [x] I have tested these changes locally
- [x] I have updated documentation as needed
- [x] I have added or updated tests as appropriate
- [x] I have used clear and descriptive commit messages

### Review

**Typical tasks**

- [ ] Merge request is well described
- [ ] Added `Obsolete` attributes if necessary
- [ ] Critical sections are *documented in code*
- [ ] *Tests* available or extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment
- [ ] *Manual* is created / updated
- [ ] Ports to other maintained versions are created

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets